### PR TITLE
example-runtime-bundle to 7.0.49

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,9 +1,12 @@
 dependencies:
-- name: exposecontroller
-  version: 2.3.58
+- name: example-runtime-bundle
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 7.0.49
+- alias: expose
+  name: exposecontroller
   repository: https://chartmuseum.build.cd.jenkins-x.io
-  alias: expose
-- name: exposecontroller
   version: 2.3.58
+- alias: cleanup
+  name: exposecontroller
   repository: https://chartmuseum.build.cd.jenkins-x.io
-  alias: cleanup
+  version: 2.3.58


### PR DESCRIPTION
Promote example-runtime-bundle to version 7.0.49