### PR TITLE
example-runtime-bundle to 7.0.60

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -16,7 +16,7 @@ dependencies:
   version: 0.1.0
 - name: example-runtime-bundle
   repository: http://jenkins-x-chartmuseum:8080
-  version: 7.0.54
+  version: 7.0.60
 - alias: expose
   name: exposecontroller
   repository: https://chartmuseum.build.cd.jenkins-x.io


### PR DESCRIPTION
Promote example-runtime-bundle to version 7.0.60